### PR TITLE
Display content field

### DIFF
--- a/Controller/MyContentController.php
+++ b/Controller/MyContentController.php
@@ -108,6 +108,7 @@ class MyContentController extends Controller
 
         return $this->render('SherlockodeAdvancedContentBundle:Content:create_content.html.twig', [
             'form' => $form->createView(),
+            'data' => $content,
         ]);
     }
 
@@ -215,5 +216,35 @@ class MyContentController extends Controller
         $om->flush();
 
         return $this->redirectToRoute('sherlockode_ac_list_mycontent');
+    }
+
+    /**
+     * @Route("/view/{id}", name="sherlockode_ac_view_mycontent")
+     *
+     * @param int                  $id
+     * @param ContentManager       $contentManager
+     * @param ConfigurationManager $configurationManager
+     *
+     * @return Response
+     *
+     * @throws EntityNotFoundException
+     */
+    public function viewAction(
+        $id,
+        ContentManager $contentManager,
+        ConfigurationManager $configurationManager
+    ) {
+        $content = $contentManager->getContentById($id);
+
+        if ($content === null) {
+            throw EntityNotFoundException::fromClassNameAndIdentifier(
+                $configurationManager->getEntityClass('content'),
+                [$id]
+            );
+        }
+
+        return $this->render('SherlockodeAdvancedContentBundle:Content:view.html.twig', [
+            'content' => $content,
+        ]);
     }
 }

--- a/FieldType/AbstractChoice.php
+++ b/FieldType/AbstractChoice.php
@@ -54,7 +54,7 @@ abstract class AbstractChoice extends AbstractFieldType
      *
      * @return array
      */
-    private function getFieldOptionsArray(FieldInterface $field)
+    protected function getFieldOptionsArray(FieldInterface $field)
     {
         $choices = [];
         $fieldOptions = $this->getFieldOptions($field);

--- a/FieldType/AbstractFieldType.php
+++ b/FieldType/AbstractFieldType.php
@@ -3,6 +3,7 @@
 namespace Sherlockode\AdvancedContentBundle\FieldType;
 
 use Sherlockode\AdvancedContentBundle\Model\FieldInterface;
+use Sherlockode\AdvancedContentBundle\Model\FieldValueInterface;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\Form\Form;
 
@@ -52,5 +53,17 @@ abstract class AbstractFieldType implements FieldTypeInterface
     public function getLabel()
     {
         return ucfirst($this->getCode());
+    }
+
+    /**
+     * Render field value
+     *
+     * @param FieldValueInterface $fieldValue
+     *
+     * @return mixed
+     */
+    public function render(FieldValueInterface $fieldValue)
+    {
+        return $fieldValue->getValue();
     }
 }

--- a/FieldType/Checkbox.php
+++ b/FieldType/Checkbox.php
@@ -4,6 +4,7 @@ namespace Sherlockode\AdvancedContentBundle\FieldType;
 
 use Sherlockode\AdvancedContentBundle\Form\DataTransformer\StringToArrayTransformer;
 use Sherlockode\AdvancedContentBundle\Model\FieldInterface;
+use Sherlockode\AdvancedContentBundle\Model\FieldValueInterface;
 use Symfony\Component\Form\FormBuilderInterface;
 
 class Checkbox extends AbstractChoice
@@ -37,5 +38,28 @@ class Checkbox extends AbstractChoice
     public function getCode()
     {
         return 'checkbox';
+    }
+
+    /**
+     * Render field value
+     *
+     * @param FieldValueInterface $fieldValue
+     *
+     * @return mixed
+     */
+    public function render(FieldValueInterface $fieldValue)
+    {
+        $value = $fieldValue->getValue();
+        $value = unserialize($value);
+
+        $values = [];
+        $options = $this->getFieldOptionsArray($fieldValue->getField());
+        foreach ($value as $valueId) {
+            if (!empty($options[$valueId])) {
+                $values[] = $options[$valueId];
+            }
+        }
+        // TODO return array of labels
+        return implode(',', $values);
     }
 }

--- a/FieldType/FieldTypeInterface.php
+++ b/FieldType/FieldTypeInterface.php
@@ -3,6 +3,7 @@
 namespace Sherlockode\AdvancedContentBundle\FieldType;
 
 use Sherlockode\AdvancedContentBundle\Model\FieldInterface;
+use Sherlockode\AdvancedContentBundle\Model\FieldValueInterface;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\Form\Form;
 
@@ -65,4 +66,13 @@ interface FieldTypeInterface
      * @return string
      */
     public function getLabel();
+
+    /**
+     * Render field value
+     *
+     * @param FieldValueInterface $fieldValue
+     *
+     * @return mixed
+     */
+    public function render(FieldValueInterface $fieldValue);
 }

--- a/FieldType/Link.php
+++ b/FieldType/Link.php
@@ -4,6 +4,7 @@ namespace Sherlockode\AdvancedContentBundle\FieldType;
 
 use Sherlockode\AdvancedContentBundle\Form\DataTransformer\StringToArrayTransformer;
 use Sherlockode\AdvancedContentBundle\Model\FieldInterface;
+use Sherlockode\AdvancedContentBundle\Model\FieldValueInterface;
 use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
 use Symfony\Component\Form\Extension\Core\Type\FormType;
 use Symfony\Component\Form\Extension\Core\Type\TextType;
@@ -84,8 +85,8 @@ class Link extends AbstractFieldType
         $builder->get('options')
             ->add('target', ChoiceType::class, [
                 'choices' => [
-                    'Blank' => 'blank',
-                    'Self' => 'self'
+                    'Blank' => '_blank',
+                    'Self' => '_self'
                 ]
             ])
         ;
@@ -99,5 +100,23 @@ class Link extends AbstractFieldType
     public function getCode()
     {
         return 'link';
+    }
+
+    /**
+     * Render field value
+     *
+     * @param FieldValueInterface $fieldValue
+     *
+     * @return mixed
+     */
+    public function render(FieldValueInterface $fieldValue)
+    {
+        $value = $fieldValue->getValue();
+        $value = unserialize($value);
+
+        $options = $this->getFieldOptions($fieldValue->getField());
+        $target = $options['target'];
+
+        return '<a href="' . $value['href'] . '" target="' . $target . '">' . $value['anchor']. '</a>';
     }
 }

--- a/FieldType/Radio.php
+++ b/FieldType/Radio.php
@@ -2,6 +2,8 @@
 
 namespace Sherlockode\AdvancedContentBundle\FieldType;
 
+use Sherlockode\AdvancedContentBundle\Model\FieldValueInterface;
+
 class Radio extends AbstractChoice
 {
     /**
@@ -17,5 +19,24 @@ class Radio extends AbstractChoice
     public function getCode()
     {
         return 'radio';
+    }
+
+    /**
+     * Render field value
+     *
+     * @param FieldValueInterface $fieldValue
+     *
+     * @return mixed
+     */
+    public function render(FieldValueInterface $fieldValue)
+    {
+        $value = $fieldValue->getValue();
+
+        $options = $this->getFieldOptionsArray($fieldValue->getField());
+        if (!empty($options[$value])) {
+            return $options[$value];
+        }
+
+        return '';
     }
 }

--- a/Resources/config/services.yml
+++ b/Resources/config/services.yml
@@ -19,3 +19,6 @@ services:
         tags: ['sherlockode_advanced_content.fieldtype']
     Sherlockode\AdvancedContentBundle\FieldType\Wysiwyg:
         tags: ['sherlockode_advanced_content.fieldtype']
+    Sherlockode\AdvancedContentBundle\Twig\Extension\:
+        resource: '../../Twig/Extension/*'
+        tags: ['twig.extension']

--- a/Resources/views/Content/view.html.twig
+++ b/Resources/views/Content/view.html.twig
@@ -1,0 +1,26 @@
+{% extends 'SherlockodeAdvancedContentBundle::layout.html.twig' %}
+{% block body %}
+    {{ parent() }}
+    <div class="container edit-content">
+        <div class="row page-info">
+            <div class="col-md-12">
+                <h1>View Content</h1>
+            </div>
+        </div>
+        <hr>
+        <div class="row">
+            <div class="col-md-12">
+                <div class="row">
+                    {% for fieldValue in content.fieldValues %}
+                        <div class="row">
+                            <div class="col-md-12">
+                                {{ acb_field(content, fieldValue.field.slug) }}
+                            </div>
+                        </div>
+                        <hr>
+                    {% endfor %}
+                </div>
+            </div>
+        </div>
+    </div>
+{% endblock %}

--- a/Twig/Extension/ContentExtension.php
+++ b/Twig/Extension/ContentExtension.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace Sherlockode\AdvancedContentBundle\Twig\Extension;
+
+use Sherlockode\AdvancedContentBundle\Manager\FieldManager;
+use Sherlockode\AdvancedContentBundle\Model\ContentInterface;
+
+class ContentExtension extends \Twig_Extension
+{
+    /**
+     * @var FieldManager
+    */
+    private $fieldManager;
+
+    public function __construct(FieldManager $fieldManager)
+    {
+        $this->fieldManager = $fieldManager;
+    }
+
+    /**
+     * Add specific twig function
+     */
+    public function getFunctions()
+    {
+        return [
+            new \Twig_SimpleFunction('acb_field', [$this, 'displayField'], ['is_safe' => ['html']]),
+        ];
+    }
+
+    /**
+     * @param ContentInterface $content
+     * @param string           $slug
+     *
+     * @return bool
+     */
+    public function displayField(ContentInterface $content, $slug)
+    {
+        foreach ($content->getFieldValues() as $fieldValue) {
+            if ($fieldValue->getField()->getSlug() == $slug) {
+                return $this->fieldManager->getFieldType($fieldValue->getField())->render($fieldValue);
+            }
+        }
+        return '';
+    }
+}


### PR DESCRIPTION
A rebase après le merge de #14 

Est-ce qu'on ajoute deux filtres twig ?
un qui renvoie uniquement du texte, et qui peut être utilisé dans le view directement
et un autre qui renvoie soit la valeur directement (pour les types de champs simples) soit un tableau qui contient ce qui est nécessaire pour un affichage custom
par exemple pour le type checkbox, le tableau des labels choisis
et pour le link, un tableau qui contient href, anchor et target 
?