### PR TITLE
Fix change type layout

### DIFF
--- a/Controller/MyContentTypeController.php
+++ b/Controller/MyContentTypeController.php
@@ -298,11 +298,15 @@ class MyContentTypeController extends Controller
         foreach ($formChildren as $child) {
             $form = $form->get($child);
         }
+        $formView = $form->createView();
 
         $response = [
             'success' => 1,
-            'html'    => $this->renderView('@SherlockodeAdvancedContent/ContentType/field_options_render.html.twig', [
-                'options' => $form->createView()['options'],
+            'optionHtml'    => $this->renderView('@SherlockodeAdvancedContent/ContentType/field_options_render.html.twig', [
+                'options' => $formView['options'],
+            ]),
+            'layoutHtml'    => $this->renderView('@SherlockodeAdvancedContent/ContentType/field_layout.html.twig', [
+                'form' => $formView,
             ])
         ];
 

--- a/Resources/public/js/content-type.js
+++ b/Resources/public/js/content-type.js
@@ -3,6 +3,7 @@ jQuery(function ($) {
 
     updateChoiceList();
     hideEmptyOptionsRow();
+    hideEmptyLayoutRow();
 
     var fieldsList;
 
@@ -28,6 +29,7 @@ jQuery(function ($) {
                 fieldsList.append(newElement);
                 newElement.find('.edit-field').click();
                 hideEmptyOptionsRow();
+                hideEmptyLayoutRow();
                 var modal = form.closest('.modal');
                 if (modal.length) {
                     modal.modal('hide');
@@ -87,9 +89,11 @@ jQuery(function ($) {
             data: data,
             context: this
         }).done(function (data) {
-            $(this).closest('div.field-row').find('.options').html(data.html);
+            $(this).closest('div.field-row').find('.options').html(data.optionHtml);
+            $(this).closest('div.field-row').find('.layout-row').html(data.layoutHtml);
             updateChoiceList();
             hideEmptyOptionsRow();
+            hideEmptyLayoutRow();
         }).fail(ajaxFailCallback);
     });
 
@@ -198,6 +202,15 @@ jQuery(function ($) {
         $('.options-row').each(function() {
             $(this).show();
             if ($(this).find('.options > .no-option').length > 0) {
+                $(this).hide();
+            }
+        });
+    }
+
+    function hideEmptyLayoutRow() {
+        $('.layout-row').each(function() {
+            $(this).show();
+            if ($(this).children().length == 0) {
                 $(this).hide();
             }
         });

--- a/Resources/views/ContentType/field_layout.html.twig
+++ b/Resources/views/ContentType/field_layout.html.twig
@@ -1,0 +1,9 @@
+{% if form['children'] is defined %}
+    {% form_theme form['children'] '@SherlockodeAdvancedContent/Form/content_type.html.twig' %}
+    <div class="col-md-2">
+        {{ form_label(form['children']) }}
+    </div>
+    <div class="col-md-10">
+        {{ form_widget(form['children']) }}
+    </div>
+{% endif %}

--- a/Resources/views/Form/content_type.html.twig
+++ b/Resources/views/Form/content_type.html.twig
@@ -154,16 +154,9 @@
                 {{ form_widget(form.hint, {'attr': {'class': 'form-control'}}) }}
             </div>
         </div>
-        {% if form['children'] is defined %}
-        <div class="form-group row">
-            <div class="col-md-2">
-                {{ form_label(form['children']) }}
-            </div>
-            <div class="col-md-10">
-                {{ form_widget(form['children']) }}
-            </div>
+        <div class="form-group row layout-row">
+            {% include '@SherlockodeAdvancedContent/ContentType/field_layout.html.twig' with {form: form} only %}
         </div>
-        {% endif %}
         <div class="form-group row options-row">
             <div class="col-md-2">
                 {{ form_label(form.options) }}


### PR DESCRIPTION
Souci quand on passe d'un champ "normal" à un champ flexible/repeater : le form pour les children est bien affiché après le changement de type, mais aucune des données n'est sauvegardée :( 
A priori, les infos sont bien formattées dans le post
Pas encore assez creusé pour voir exactement d'où vient le problème, mais j'aurais peut-être besoin d'un coup de pouce pour mieux comprendre comment les flexibles/repeaters sont gérés