### PR TITLE
Compat Doctrine ORM 3 des EventListener (postLoad/prePersist/onFlush)

### DIFF
--- a/EventListener/ContentListener.php
+++ b/EventListener/ContentListener.php
@@ -4,8 +4,8 @@ declare(strict_types=1);
 
 namespace Sherlockode\AdvancedContentBundle\EventListener;
 
-use Doctrine\ORM\Event\LifecycleEventArgs;
 use Doctrine\ORM\Event\OnFlushEventArgs;
+use Doctrine\ORM\Event\PostLoadEventArgs;
 use Sherlockode\AdvancedContentBundle\Manager\ConfigurationManager;
 use Sherlockode\AdvancedContentBundle\Manager\VersionManager;
 use Sherlockode\AdvancedContentBundle\Model\ContentInterface;
@@ -18,9 +18,9 @@ class ContentListener
     ) {
     }
 
-    public function postLoad(LifecycleEventArgs $args): void
+    public function postLoad(PostLoadEventArgs $args): void
     {
-        $entity = $args->getEntity();
+        $entity = $args->getObject();
 
         if (!$entity instanceof ContentInterface) {
             return;
@@ -35,7 +35,7 @@ class ContentListener
 
     public function onFlush(OnFlushEventArgs $args): void
     {
-        $em = $args->getEntityManager();
+        $em = $args->getObjectManager();
         $uow = $em->getUnitOfWork();
 
         $entities = [

--- a/EventListener/PageListener.php
+++ b/EventListener/PageListener.php
@@ -4,8 +4,9 @@ declare(strict_types=1);
 
 namespace Sherlockode\AdvancedContentBundle\EventListener;
 
-use Doctrine\ORM\Event\LifecycleEventArgs;
 use Doctrine\ORM\Event\OnFlushEventArgs;
+use Doctrine\ORM\Event\PostLoadEventArgs;
+use Doctrine\ORM\Event\PrePersistEventArgs;
 use Sherlockode\AdvancedContentBundle\Manager\ConfigurationManager;
 use Sherlockode\AdvancedContentBundle\Manager\VersionManager;
 use Sherlockode\AdvancedContentBundle\Model\ContentInterface;
@@ -20,9 +21,9 @@ class PageListener
     ) {
     }
 
-    public function postLoad(LifecycleEventArgs $args): void
+    public function postLoad(PostLoadEventArgs $args): void
     {
-        $entity = $args->getEntity();
+        $entity = $args->getObject();
 
         if (!$entity instanceof PageInterface) {
             return;
@@ -57,7 +58,7 @@ class PageListener
         }
     }
 
-    public function prePersist(LifecycleEventArgs $args): void
+    public function prePersist(PrePersistEventArgs $args): void
     {
         $object = $args->getObject();
 
@@ -72,7 +73,7 @@ class PageListener
 
     public function onFlush(OnFlushEventArgs $args): void
     {
-        $em = $args->getEntityManager();
+        $em = $args->getObjectManager();
         $uow = $em->getUnitOfWork();
 
         $entities = [

--- a/EventListener/VersionListener.php
+++ b/EventListener/VersionListener.php
@@ -4,16 +4,16 @@ declare(strict_types=1);
 
 namespace Sherlockode\AdvancedContentBundle\EventListener;
 
-use Doctrine\ORM\Event\LifecycleEventArgs;
+use Doctrine\ORM\Event\PrePersistEventArgs;
 use Sherlockode\AdvancedContentBundle\Model\ContentVersionInterface;
 use Sherlockode\AdvancedContentBundle\Model\PageVersionInterface;
 use Sherlockode\AdvancedContentBundle\Model\VersionInterface;
 
 class VersionListener
 {
-    public function prePersist(LifecycleEventArgs $args): void
+    public function prePersist(PrePersistEventArgs $args): void
     {
-        $entity = $args->getEntity();
+        $entity = $args->getObject();
 
         if (!$entity instanceof VersionInterface || !$entity->isAutoSave()) {
             return;
@@ -43,7 +43,7 @@ class VersionListener
 
             if ($count >= 10) {
                 // Keep only the last 10 drafts by same user
-                $args->getEntityManager()->remove($version);
+                $args->getObjectManager()->remove($version);
             }
         }
     }


### PR DESCRIPTION
LifecycleEventArgs (Doctrine\ORM\Event) supprime en ORM 3 ; getEntity() et OnFlushEventArgs::getEntityManager() retires. Passage aux args dedies par evenement (PostLoadEventArgs/PrePersistEventArgs) + getObject()/getObjectManager().